### PR TITLE
enable use of a meta-data design.df that contains a strict subset of …

### DIFF
--- a/R/calcNhoodDistance.R
+++ b/R/calcNhoodDistance.R
@@ -61,7 +61,7 @@ calcNhoodDistance <- function(x, d, reduced.dim=NULL, use.assay="logcounts"){
     }
 
     non.zero.nhoods <- which(nhoods(x)!=0, arr.ind = TRUE)
-    
+
     if(any(names(reducedDims(x)) %in% c("PCA"))){
         nhood.dists <- sapply(1:ncol(nhoods(x)),
                               function(X) .calc_distance(reducedDim(x, "PCA")[non.zero.nhoods[non.zero.nhoods[,'col']==X,'row'], c(1:d),drop=FALSE]))
@@ -99,7 +99,7 @@ calcNhoodDistance <- function(x, d, reduced.dim=NULL, use.assay="logcounts"){
     dist.df <- do.call(rbind.data.frame, dist.list)
     out.dist <- sparseMatrix(i=dist.df$rowIndex, j=dist.df$colIndex, x=dist.df$dist,
                              dimnames=list(rownames(in.x), rownames(in.x)),
-                             giveCsparse=FALSE)
+                             repr="T")
     return(out.dist)
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -10,7 +10,7 @@
         return(length(x.slot[[1]]) > 0)
     } else if(is.list(x.slot) & is.null(names(x.slot))){
         return(length(x.slot))
-    } else if(any(class(x.slot) %in% c("dgCMatrix", "dsCMatrix", "matrix"))){
+    } else if(any(class(x.slot) %in% c("dgCMatrix", "dsCMatrix", "ddiMatrix", "matrix"))){
         return(sum(rowSums(x.slot)) == 0)
     }
 }


### PR DESCRIPTION
…samples used to construct nhoods/count cells in nhoods.

`design.df` can be passed to `testNhoods` where the `rownames(design.df)` are a strict subset of `colnames(nhoodCounts(x))`.  This allows testing on a subset of samples without having to recompute the single-cell graph and neighbourhoods.