### PR TITLE
Adding check for rownames order in design_df

### DIFF
--- a/R/testNhoods.R
+++ b/R/testNhoods.R
@@ -122,6 +122,10 @@ testNhoods <- function(x, design, design.df,
             stop(paste0("Design matrix (", nrow(model), ") and nhood counts (",
                         ncol(nhoodCounts(x)), ") are not the same dimension"))
         }
+    } 
+    if(colnames(nhoodCounts(x)) != rownames(model)){
+        stop(paste0("Sample names in design matrix and nhood counts are not matched. 
+                    Reorder rows in design matrix."))
     }
 
     # assume nhoodCounts and model are in the same order


### PR DESCRIPTION
At the moment if you give to `testNhoods` a data.frame in `design.df` where rownames correspond to colnames of `nhoodCounts(x)` but in different order, the test will find no significant DA nhoods. For now I have just added a check at the beginning that propts the user to reorder the rownames in `design.df`