### PR TITLE
fixing if statement in testNhoods

### DIFF
--- a/R/testNhoods.R
+++ b/R/testNhoods.R
@@ -124,7 +124,7 @@ testNhoods <- function(x, design, design.df,
         }
     }
 
-    if((colnames(nhoodCounts(x)) != rownames(model)) & !any(colnames(nhoodCounts(x)) %in% rownames(model))){
+    if(any(colnames(nhoodCounts(x)) != rownames(model)) & !any(colnames(nhoodCounts(x)) %in% rownames(model))){
         stop(paste0("Sample names in design matrix and nhood counts are not matched.
                     Set appropriate rownames in design matrix."))
     } else if((colnames(nhoodCounts(x)) != rownames(model)) & any(colnames(nhoodCounts(x)) %in% rownames(model))){


### PR DESCRIPTION
small fix in check for rownames in design matrix, which was throwing warning:
```
Warning messages:
1: In if ((colnames(nhoodCounts(x)) != rownames(model)) & !any(colnames(nhoodCounts(x)) %in%  :
  the condition has length > 1 and only the first element will be used
```