### PR TITLE
Checks the rowname ordering from DGE testing for nhood group markers

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: miloR
 Type: Package
 Title: Differential neighbourhood abundance testing on a graph
-Version: 0.99.0
+Version: 0.99.1
 Authors@R:
     c(person("Mike", "Morgan", role=c("aut", "cre"), email="michael.morgan@cruk.cam.ac.uk"),
     person("Emma", "Dann", role=c("aut", "ctb"), email="ed6@sanger.ac.uk"))

--- a/R/findNhoodGroupMarkers.R
+++ b/R/findNhoodGroupMarkers.R
@@ -253,7 +253,6 @@ findNhoodGroupMarkers <- function(x, da.res, assay="logcounts",
   }
 
   colnames(marker.df) <- gsub(colnames(marker.df), pattern="^[0-9]+\\.", replacement="")
-  marker.df$GeneID <- rownames(i.res)
 
   return(marker.df)
   }

--- a/R/findNhoodGroupMarkers.R
+++ b/R/findNhoodGroupMarkers.R
@@ -238,7 +238,20 @@ findNhoodGroupMarkers <- function(x, da.res, assay="logcounts",
     sink(file=NULL)
   }
 
-  marker.df <- do.call(cbind.data.frame, marker.list)
+  # check all rownames orders are the same
+  concord.rownames <- Reduce(x=marker.list, f=function(x, y) all(rownames(x) == rownames(y)))
+  if(isTRUE(all(concord.rownames))){
+    marker.df <- do.call(cbind.data.frame, marker.list)
+  } else{
+    warning("Rownames of DGE results are reordered")
+    n.rows <- lapply(marker.list, nrow)
+    if(length(unique(n.rows)) > 1){
+      warning("Not all DGE results contain the same features - results may be truncated")
+    }
+    # merge on rownames
+    marker.df <- Reduce(x=marker.list, f=function(x, y) merge(x, y, by=0))
+  }
+
   colnames(marker.df) <- gsub(colnames(marker.df), pattern="^[0-9]+\\.", replacement="")
   marker.df$GeneID <- rownames(i.res)
 

--- a/tests/testthat/test_findNhoodGroupMarkers.R
+++ b/tests/testthat/test_findNhoodGroupMarkers.R
@@ -112,7 +112,7 @@ test_that("Incorrect input gives the expected errors", {
 
     expect_error(findNhoodGroupMarkers(sim1.mylo, sim1.res, assay="junk"),
                  "Unrecognised assay slot")
-    
+
     expect_error(findNhoodGroupMarkers(sim1.mylo, sim1.res),
                  "'NhoodGroup' columns is missing from da.res")
 
@@ -124,8 +124,7 @@ test_that("Incorrect input gives the expected errors", {
 sim1.res <- groupNhoods(sim1.mylo, sim1.res, overlap = 5)
 
 test_that("Less than optimal input gives the expected warnings", {
-    expect_warning(suppressMessages(findNhoodGroupMarkers(sim1.mylo, sim1.res, na.function=NULL,
-                                                     compute.new=TRUE)),
+    expect_warning(suppressMessages(findNhoodGroupMarkers(sim1.mylo, sim1.res, na.function=NULL)),
                    "NULL passed to na.function, using na.pass")
 
     # add simulated CPMs to the data
@@ -137,25 +136,21 @@ test_that("Less than optimal input gives the expected warnings", {
     rownames(ux.cpm) <- rownames(sim1.mylo)
 
     SingleCellExperiment::cpm(sim1.mylo) <- ux.cpm
-    expect_warning(suppressMessages(findNhoodGroupMarkers(sim1.mylo, sim1.res, assay="cpm",
-                                                     compute.new=TRUE)),
+    expect_warning(suppressMessages(findNhoodGroupMarkers(sim1.mylo, sim1.res, assay="cpm")),
                    "Assay type is not counts or logcounts")
 })
 
 
 test_that("Output is correct type", {
-    full.out <- suppressWarnings(findNhoodGroupMarkers(sim1.mylo, sim1.res,
-                                                  compute.new=TRUE))
+    full.out <- suppressWarnings(findNhoodGroupMarkers(sim1.mylo, sim1.res))
     expect_identical(class(full.out) , "data.frame")
 })
 
 
 test_that("Row subsetting returns expected number of results", {
-    full.out <- suppressWarnings(findNhoodGroupMarkers(sim1.mylo, sim1.res,
-                                                  compute.new=TRUE))
+    full.out <- suppressWarnings(findNhoodGroupMarkers(sim1.mylo, sim1.res))
 
     subset.out <- suppressWarnings(findNhoodGroupMarkers(sim1.mylo, sim1.res,
-                                                    compute.new=TRUE,
                                                     subset.row=c(1:100)))
 
     expect_true(nrow(full.out) > nrow(subset.out))
@@ -164,7 +159,6 @@ test_that("Row subsetting returns expected number of results", {
 test_that("Nhood subsetting returns without error", {
     sub.nhoods <- sim1.res[1:20,"Nhood"]
     expect_error(suppressWarnings(findNhoodGroupMarkers(sim1.mylo, sim1.res,
-                                                   compute.new=TRUE,
                                                    subset.nhoods=sub.nhoods)),
                  NA)
     })


### PR DESCRIPTION
A warning will be issued in `findNhoodGroupMarkers` if either:
* the DGE testing produces output with rownames in different orders
* the DGE testing produces different numbers of genes 