### PR TITLE
Windows fix

### DIFF
--- a/.github/workflows/RCMD_check.yml
+++ b/.github/workflows/RCMD_check.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
-#          - {os: windows-latest, r: 'release'}
+          - {os: windows-latest, r: 'release'}
           - {os: macOS-latest, r: 'release'}
           - {os: ubuntu-20.04, r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
 #          - {os: ubuntu-20.04, r: 'devel', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}

--- a/R/buildGraph.R
+++ b/R/buildGraph.R
@@ -135,9 +135,6 @@ buildGraph <- function(x, k=10, d=50, transposed=FALSE, get.distance=FALSE,
     nn.out <- .setup_knn_data(x=reducedDim(x, reduced.dim), d=d,
                               k=k, BNPARAM=BNPARAM, BSPARAM=BSPARAM,
                               BPPARAM=BPPARAM)
-    sink(file="/dev/null")
-    gc()
-    sink(file=NULL)
 
     # separate graph and distances? At some point need to expand the distances
     # to the larger neighbourhood
@@ -162,10 +159,6 @@ buildGraph <- function(x, k=10, d=50, transposed=FALSE, get.distance=FALSE,
         }
         old.dist <- as(old.dist, "dgCMatrix")
         nhoodDistances(x) <- old.dist
-
-        sink(file="/dev/null")
-        gc()
-        sink(file=NULL)
     }
     x@.k <- k
     x

--- a/R/calcNhoodDistance.R
+++ b/R/calcNhoodDistance.R
@@ -71,12 +71,6 @@ calcNhoodDistance <- function(x, d, reduced.dim=NULL, use.assay="logcounts"){
         names(nhood.dists) <- nhoodIndex(x)
     }
 
-    # ensure garbage collection
-    sink(file="/dev/null")
-    gc()
-    sink(file=NULL)
-    # all.dist <- .aggregate_dists.hard(nhoods(x), nhood.dists, colnames(x))
-    # strictly this only actually needs to be a list of distance matrices
     nhoodDistances(x) <- nhood.dists
 
     return(x)
@@ -198,11 +192,6 @@ calcNhoodDistance <- function(x, d, reduced.dim=NULL, use.assay="logcounts"){
                 if(ncol(sp.out) != nrow(sp.out)){
                     stop("Matrix corrupted - dimensions are not the same size")
                 }
-                sink(file="/dev/null")
-                rm(list=c(".tmp.i", ".tmp.j"))
-                gc()
-                sink(file=NULL)
-                print(dim(sp.out))
             }
         }
         ix <- ix + 1

--- a/R/findNhoodGroupMarkers.R
+++ b/R/findNhoodGroupMarkers.R
@@ -208,10 +208,6 @@ findNhoodGroupMarkers <- function(x, da.res, assay="logcounts",
       rownames(i.model) <- rownames(i.meta)
     }
 
-    sink(file="/dev/null")
-    gc()
-    sink(file=NULL)
-
     if(assay == "logcounts"){
       i.res <- .perform_lognormal_dge(exprs, i.model, model.contrasts=i.contrast,
                                       gene.offset=gene.offset)
@@ -233,9 +229,6 @@ findNhoodGroupMarkers <- function(x, da.res, assay="logcounts",
     colnames(i.res) <- paste(colnames(i.res), nhood.gr[i], sep="_")
     marker.list[[paste0(nhood.gr[i])]] <- i.res
 
-    sink(file="/dev/null")
-    gc()
-    sink(file=NULL)
   }
 
   # check all rownames orders are the same

--- a/R/findNhoodMarkers.R
+++ b/R/findNhoodMarkers.R
@@ -287,9 +287,6 @@ findNhoodMarkers <- function(x, da.res, da.fdr=0.1, assay="logcounts",
             rownames(i.model) <- rownames(i.meta)
         }
 
-        sink(file="/dev/null")
-        gc()
-        sink(file=NULL)
 
         if(assay == "logcounts"){
             i.res <- .perform_lognormal_dge(exprs, i.model, model.contrasts=i.contrast,
@@ -312,9 +309,6 @@ findNhoodMarkers <- function(x, da.res, da.fdr=0.1, assay="logcounts",
         colnames(i.res) <- paste(colnames(i.res), nhood.gr[i], sep="_")
         marker.list[[paste0(nhood.gr[i])]] <- i.res
 
-        sink(file="/dev/null")
-        gc()
-        sink(file=NULL)
     }
 
     marker.df <- do.call(cbind.data.frame, marker.list)

--- a/R/makeNhoods.R
+++ b/R/makeNhoods.R
@@ -80,7 +80,7 @@ makeNhoods <- function(x, prop=0.1, k=21, d=30, refined=TRUE, reduced_dims="PCA"
         }
 
     sampled_vertices <- unique(sampled_vertices)
-    
+
     nh_mat <- Matrix(data = 0, nrow=ncol(x), ncol=length(sampled_vertices), sparse = TRUE)
     # Is there an alternative to using a for loop to populate the sparseMatrix here?
     for (X in 1:length(sampled_vertices)){
@@ -164,10 +164,6 @@ makeNhoods <- function(x, prop=0.1, k=21, d=30, refined=TRUE, reduced_dims="PCA"
         vertex.list <- sapply(1:length(random.vertices), FUN=function(X) neighbors(graph, v=random.vertices[X]))
         return(list(random.vertices, vertex.list))
     }
-
-    sink(file="/dev/null")
-    gc()
-    sink(file=NULL)
 }
 
 

--- a/R/methods.R
+++ b/R/methods.R
@@ -269,10 +269,6 @@ setMethod("nhoodAdjacency<-", "Milo", function(x, value){
     coolcat("nhoodReducedDim names(%d): %s\n", names(object@nhoodReducedDim))
     coolcat("nhoodGraph names(%d): %s\n", names(object@nhoodGraph))
     coolcat("nhoodAdjacency dimension(%d): %s\n", dim(object@nhoodAdjacency))
-
-    sink(file="/dev/null")
-    gc()
-    sink(file=NULL)
 }
 
 #' @export

--- a/R/plotNhoods.R
+++ b/R/plotNhoods.R
@@ -716,7 +716,7 @@ plotNhoodMA <- function(da.res, alpha=0.05, null.mean=0){
   max.lfc <- max(abs(da.res$logFC))
   max.eps <- max.lfc * 0.1
 
-  emp.null <- median(da.res$logFC)
+  emp.null <- mean(da.res$logFC)
   min.x <- min(da.res$logCPM)
   minx.eps <- min.x * 0.01
   max.x <- max(da.res$logCPM)

--- a/R/testDiffExp.R
+++ b/R/testDiffExp.R
@@ -176,10 +176,6 @@ testDiffExp <- function(x, da.res, design, meta.data, model.contrasts=NULL,
         x <- x[subset.row, , drop=FALSE]
     }
 
-    sink(file="/dev/null")
-    gc()
-    sink(file=NULL)
-
     # perform DGE _within_ each group of cells using the input design matrix
     dge.list <- list()
     for(i in seq_along(nhood.gr)){

--- a/R/testNhoods.R
+++ b/R/testNhoods.R
@@ -107,8 +107,19 @@ testNhoods <- function(x, design, design.df,
         rownames(model) <- rownames(design.df)
     } else if(is(design, "matrix")){
         model <- design
+        if(nrow(model) != nrow(design.df)){
+            stop("Design matrix and model matrix are not the same dimensionality")
+        }
+
         if(any(rownames(model) != rownames(design.df))){
-            warning("Design matrix and design matrix dimnames are not the same")
+            warning("Design matrix and model matrix dimnames are not the same")
+            # check if rownames are a subset of the design.df
+            check.names <- any(rownames(model) %in% rownames(design.df))
+            if(isTRUE(check.names)){
+                rownames(model) <- rownames(design.df)
+            } else{
+                stop("Design matrix and model matrix rownames are not a subset")
+            }
         }
     }
 

--- a/tests/testthat/test_testNhoods.R
+++ b/tests/testthat/test_testNhoods.R
@@ -109,15 +109,26 @@ test_that("Wrong input gives errors", {
 
 sim1.mylo <- countCells(sim1.mylo, samples="Sample", meta.data=meta.df)
 
-test_that("Discordant dimension names gives a warning", {
+test_that("Discordant dimension names gives an error", {
     design.matrix <- model.matrix(~Condition, data=sim1.meta)
     rownames(design.matrix) <- c(1:nrow(design.matrix))
+    expect_error(suppressWarnings(testNhoods(sim1.mylo, design=design.matrix,
+                                             design.df=sim1.meta)),
+                                  "Design matrix and model matrix rownames are not a subset")
+
+    # warning if only a subset are present, or order is wrong
+    design.matrix <- model.matrix(~Condition, data=sim1.meta)
+    rownames(design.matrix) <- rownames(sim1.meta)
+
+    set.seed(42)
+    design.matrix <- design.matrix[sample(rownames(design.matrix)), ]
     expect_warning(testNhoods(sim1.mylo, design=design.matrix,
-                                      design.df=sim1.meta),
-                   "Design matrix and design matrix dimnames are not the same")
+                              design.df=sim1.meta),
+                   "Sample names in design matrix and nhood counts are not matched. Reordering")
+
 })
 
-test_that("Discordant dimensions between input and design gives and error", {
+test_that("Discordant dimensions between input and design gives an error", {
     add.meta <- sim1.meta[c(1:5), ]
     rownames(add.meta) <- paste0(rownames(add.meta), "_add")
     big.meta <- rbind.data.frame(sim1.meta, add.meta)
@@ -125,8 +136,9 @@ test_that("Discordant dimensions between input and design gives and error", {
 
     expect_error(suppressWarnings(testNhoods(sim1.mylo, design=design.matrix,
                                                      design.df=sim1.meta)),
-                 "not the same dimension")
+                 "Design matrix and model matrix are not the same dimensionality")
 })
+
 
 test_that("Concordant dimensions between input and output", {
     in.rows <- nrow(nhoodCounts(sim1.mylo))


### PR DESCRIPTION
Remove calls to /dev/null which is not present on Windows systems. Also fix errors in testNhoods unit tests with reordered design matrix rownames.