### PR TITLE
graphSpatialFDR ignores reduced dim if not "PCA"

### DIFF
--- a/R/buildFromAdjacency.R
+++ b/R/buildFromAdjacency.R
@@ -96,5 +96,8 @@ buildFromAdjacency <- function(x, k=NULL, is.binary=NULL, ...){
         nhoodDistances(mylo) <- NULL
     }
 
+    # set internal k slot
+    mylo@.k <- k.val
+
     return(mylo)
 }

--- a/R/makeNhoods.R
+++ b/R/makeNhoods.R
@@ -15,7 +15,7 @@
 #' X reduced dimensions.
 #' @param reduced_dims If x is an \code{\linkS4class{Milo}} object, a character indicating the name of the \code{reducedDim} slot in the
 #' \code{\linkS4class{Milo}} object to use as (default: 'PCA'). If x is an \code{igraph} object, a
-#' matrix of vertices X reduced dimensions.
+#' matrix of vertices X reduced dimensions with \code{rownames()} set to correspond to the cellIDs.
 #' @param refined A logical scalar that determines the sampling behaviour, default=TRUE implements the refined sampling scheme.
 #'
 #' @details
@@ -64,13 +64,24 @@ makeNhoods <- function(x, prop=0.1, k=21, d=30, refined=TRUE, reduced_dims="PCA"
         }
         X_reduced_dims  <- X_reduced_dims[,seq_len(d)]
         mat_cols <- ncol(x)
+        match.ids <- all(rownames(X_reduced_dims) == colnames(x))
+        if(!match.ids){
+            stop("Rownames of reduced dimensions do not match cell IDs")
+        }
+
     } else if(is(x, "igraph")){
         if(!is.matrix(reduced_dims) & isTRUE(refined)){
             stop("No reduced dimensions matrix provided - required for refined sampling")
         }
+
         graph <- x
         X_reduced_dims <- reduced_dims
         mat_cols <- nrow(X_reduced_dims)
+
+        if(is.null(rownames(X_reduced_dims))){
+            stop("Reduced dim rownames are missing - required to assign cell IDs to neighbourhoods")
+        }
+
     } else{
         stop("Data format: ", class(x), " not recognised. Should be Milo or igraph")
     }
@@ -88,8 +99,11 @@ makeNhoods <- function(x, prop=0.1, k=21, d=30, refined=TRUE, reduced_dims="PCA"
     # Is there an alternative to using a for loop to populate the sparseMatrix here?
     # if vertex names are set (as can happen with graphs from 3rd party tools), then set rownames of nh_mat
     v.class <- class(V(graph)$name)
-    if(!is.null(v.class)){
+
+    if(!is.null(v.class) & is(x, "igraph")){
         rownames(nh_mat) <- rownames(X_reduced_dims)
+    } else if(!is.null(v.class) & is(x, "Milo")){
+        rownames(nh_mat) <- colnames(x)
     }
 
     for (X in seq_len(length(sampled_vertices))){

--- a/R/testNhoods.R
+++ b/R/testNhoods.R
@@ -28,6 +28,8 @@
 #' method by Anders & Huber, 2010, to compute normalisation factors relative to a reference computed from
 #' the geometric mean across samples.  The latter methods provides a degree of robustness against false positives
 #' when there are very large compositional differences between samples.
+#' @param reduced.dim A character scalar referring to the reduced dimensional slot used to compute distances for
+#' the spatial FDR. This should be the same as used for graph building.
 #'
 #'
 #' @details
@@ -102,7 +104,7 @@ NULL
 #' @importFrom edgeR DGEList estimateDisp glmQLFit glmQLFTest topTags calcNormFactors
 testNhoods <- function(x, design, design.df,
                        fdr.weighting=c("k-distance", "neighbour-distance", "max", "none"),
-                       min.mean=0, model.contrasts=NULL, robust=TRUE,
+                       min.mean=0, model.contrasts=NULL, robust=TRUE, reduced.dim="PCA",
                        norm.method=c("TMM", "RLE", "logMS")){
     if(is(design, "formula")){
         model <- model.matrix(design, data=design.df)
@@ -133,6 +135,10 @@ testNhoods <- function(x, design, design.df,
 
     if(!any(norm.method %in% c("TMM", "logMS", "RLE"))){
         stop("Normalisation method ", norm.method, " not recognised. Must be either TMM, RLE or logMS")
+    }
+
+    if(!reduced.dim %in% reducedDimNames(x)){
+        stop(reduced.dim, " is not found in reducedDimNames. Avaiable options are ", paste(reducedDimNames(x), collapse=","))
     }
 
     subset.counts <- FALSE
@@ -219,7 +225,7 @@ testNhoods <- function(x, design, design.df,
                                       pvalues=res[order(res$Nhood), ]$PValue,
                                       indices=nhoodIndex(x),
                                       distances=nhoodDistances(x),
-                                      reduced.dimensions=reducedDim(x, "PCA"))
+                                      reduced.dimensions=reducedDim(x, reduced.dim))
 
     res$SpatialFDR[order(res$Nhood)] <- mod.spatialfdr
     res

--- a/tests/testthat/test_testNhoods.R
+++ b/tests/testthat/test_testNhoods.R
@@ -105,6 +105,12 @@ test_that("Wrong input gives errors", {
                             design.df=sim1.meta[colnames(nhoodCounts(sim1.mylo)), ]),
                  "Unrecognised input type - must be of class Milo")
 
+    # missing reduced dimension slot
+    expect_error(testNhoods(sim1.mylo, design=~Condition,
+                            design.df=sim1.meta[colnames(nhoodCounts(sim1.mylo)), ],
+                            reduced.dim="blah"),
+                 "is not found in reducedDimNames")
+
 })
 
 sim1.mylo <- countCells(sim1.mylo, samples="Sample", meta.data=meta.df)

--- a/vignettes/milo_gastrulation.Rmd
+++ b/vignettes/milo_gastrulation.Rmd
@@ -176,7 +176,7 @@ embryo_milo <- calcNhoodDistance(embryo_milo, d=30, reduced.dim = "pca.corrected
 Now we can do the DA test, explicitly defining our experimental design. In this case, we want to test for differences between experimental stages, while accounting for the variability between technical batches (You can find more info on how to use formulas to define a testing design in R [here](https://r4ds.had.co.nz/model-basics.html#formulas-and-model-families))
 
 ```{r}
-da_results <- testNhoods(embryo_milo, design = ~ sequencing.batch + stage, design.df = embryo_design)
+da_results <- testNhoods(embryo_milo, design = ~ sequencing.batch + stage, design.df = embryo_design, reduced.dim="pca.corrected")
 head(da_results)
 ```
 


### PR DESCRIPTION
For `Milo` objects that did not contain a "PCA" slot in `reducedDim`, when running `spatialGraphFDR` inside `testNhoods` would silently fail and return all NAs. This PR fixes this bug by allowing (a) user-specified `reduced.dim` argument to `testNhoods`, which then checks if this is present in the `reducedDimNames` argument of the input `Milo` object.

A patch for #167 to check for concordant reducedDimension rownames and object colnames.