### PR TITLE
kth nn distance to index cell in GraphSpatialFDR

### DIFF
--- a/R/graphSpatialFDR.R
+++ b/R/graphSpatialFDR.R
@@ -107,10 +107,17 @@ graphSpatialFDR <- function(x.nhoods, graph, pvalues, k=NULL, weighting='k-dista
                 # find the distance to the kth nearest neighbour within the distance matrix
                 t.connect <- unlist(lapply(indices, FUN=function(X) distances[X, ][order(distances[X, ], decreasing=FALSE)[k]]))
             } else if(class(distances) %in% c("list")){
+                # check if row names are set
+                if(!is.null(rownames(distances))){
+                    t.dists <- lapply(indices, FUN=function(X) as.numeric(distances[[as.character(X)]][as.character(X), ]))
+                    t.connect <- unlist(lapply(t.dists, FUN=function(Q) (Q[Q>0])[order(Q[Q>0], decreasing=FALSE)[k]]))
+                } else {
+                # if row names are not set, extract numeric indices
+                non.zero.nhoods <- which(nhoods(x)!=0, arr.ind = TRUE)
                 t.dists <- lapply(indices,
-                                  FUN=function(X) as.numeric(tril(distances[[as.character(X)]])))
+                                  FUN=function(X) distances[[as.character(X)]][which(non.zero.nhoods[non.zero.nhoods[,2] == which(indices == X),][,1] == X),])
                 t.connect <- unlist(lapply(t.dists, FUN=function(Q) (Q[Q>0])[order(Q[Q>0], decreasing=FALSE)[k]]))
-
+                }
             } else{
                 stop("Neighbourhood distances must be either a matrix or a list of matrices")
             }

--- a/R/graphSpatialFDR.R
+++ b/R/graphSpatialFDR.R
@@ -47,6 +47,7 @@ NULL
 #' @importFrom Matrix rowMeans tril
 #' @importFrom stats dist
 #' @importFrom BiocNeighbors findKNN
+#' @importFrom BiocGenerics which
 graphSpatialFDR <- function(x.nhoods, graph, pvalues, k=NULL, weighting='k-distance',
                             reduced.dimensions=NULL, distances=NULL, indices=NULL){
 
@@ -113,7 +114,7 @@ graphSpatialFDR <- function(x.nhoods, graph, pvalues, k=NULL, weighting='k-dista
                     t.connect <- unlist(lapply(t.dists, FUN=function(Q) (Q[Q>0])[order(Q[Q>0], decreasing=FALSE)[k]]))
                 } else {
                 # if row names are not set, extract numeric indices
-                non.zero.nhoods <- which(nhoods(x)!=0, arr.ind = TRUE)
+                non.zero.nhoods <- which(x.nhoods!=0, arr.ind = TRUE)
                 t.dists <- lapply(indices,
                                   FUN=function(X) distances[[as.character(X)]][which(non.zero.nhoods[non.zero.nhoods[,2] == which(indices == X),][,1] == X),])
                 t.connect <- unlist(lapply(t.dists, FUN=function(Q) (Q[Q>0])[order(Q[Q>0], decreasing=FALSE)[k]]))

--- a/tests/testthat/test_graphSpatialFDR.R
+++ b/tests/testthat/test_graphSpatialFDR.R
@@ -227,7 +227,7 @@ test_that("graphSpatialFDR produces reproducible results for k-distance weightin
         pvalues <- pvalues[haspval]
     }
     k <- sim1.mylo@.k
-    non.zero.nhoods <- which(x.nhoods!=0, arr.ind = TRUE)
+    non.zero.nhoods <- which(nhoods!=0, arr.ind = TRUE)
     t.dists <- lapply(indices, FUN=function(X) distances[[as.character(X)]][which(non.zero.nhoods[non.zero.nhoods[,2] == which(indices == X),][,1] == X),])
     t.connect <- unlist(lapply(t.dists, FUN=function(Q) (Q[Q>0])[order(Q[Q>0], decreasing=FALSE)[k]]))
 

--- a/tests/testthat/test_graphSpatialFDR.R
+++ b/tests/testthat/test_graphSpatialFDR.R
@@ -227,8 +227,8 @@ test_that("graphSpatialFDR produces reproducible results for k-distance weightin
         pvalues <- pvalues[haspval]
     }
     k <- sim1.mylo@.k
-    t.dists <- lapply(indices,
-                      FUN=function(X) as.numeric(tril(distances[[as.character(X)]])))
+    non.zero.nhoods <- which(x.nhoods!=0, arr.ind = TRUE)
+    t.dists <- lapply(indices, FUN=function(X) distances[[as.character(X)]][which(non.zero.nhoods[non.zero.nhoods[,2] == which(indices == X),][,1] == X),])
     t.connect <- unlist(lapply(t.dists, FUN=function(Q) (Q[Q>0])[order(Q[Q>0], decreasing=FALSE)[k]]))
 
     #t.connect <- unlist(lapply(indices, FUN=function(X) max(distances[[as.character(X)]])))


### PR DESCRIPTION
Including missing subsetting to select kth-nn distances from index cell only. Added two ways to do this, depending on whether row names are present or not. Had to include function which from BiocGenerics.