### PR TITLE
Patch for no overlap edge case with graph-based spatialFDR

### DIFF
--- a/R/graphSpatialFDR.R
+++ b/R/graphSpatialFDR.R
@@ -158,7 +158,7 @@ graphSpatialFDR <- function(x.nhoods, graph, pvalues, k=NULL, weighting='k-dista
 
     # use 1/connectivity as the weighting for the weighted BH adjustment from Cydar
     w <- 1/unlist(t.connect)
-    w[is.infinite(w)] <- 0
+    w[is.infinite(w)] <- 1
 
     # Computing a density-weighted q-value.
     o <- order(pvalues)


### PR DESCRIPTION
This came up from discussion and live unit testing with @amissarova and @jcmarioni. When using `weighting = "graph-overlap"` in `graphSpatialFDR`, if there is a neighbourhood that has no overlap with other neighbourhoods (so the reciprocal becomes infinite), then the weight for the FDR correction is set to 0
https://github.com/MarioniLab/miloR/blob/3d9d55b45dd7a58436958bd3242e4a491bcb9970/R/graphSpatialFDR.R#L159-L161  

Firstly, this introduces a pathological case: when the lowest p-value has w=0, then the `adjp` becomes nan. Secondly, this appears to be over-conservative: if the nhood doesn't overlap any other neighbourhood then the statistical test here is completely independent of the other tests, hence it should not be penalized in multiple testing correction. Also, if a neighbourhood is isolated, and therefore the only neighbourhood covering a region of the graph, arguably it's more important to avoid false negatives here. So this patch changes the above to 
```
w[is.infinite(w)] <- 1
``` 

This is a patch because while being a rather rare edge case in DA analysis, there are situations where having the smallest amount of neighbourhoods possible becomes important (hence more likely to have no overlap) and it might make more sense to account for the size of the neighbourhood too. Alsu is trying  alternative measures of density of neighbourhoods for graph refinement.