### PR TITLE
Resolve matrix commute error in model using random effect and GRM at the same time.

### DIFF
--- a/R/glmm.R
+++ b/R/glmm.R
@@ -179,7 +179,6 @@ fitGLMM <- function(X, Z, y, offsets, init.theta=NULL, Kin=NULL,
         geno.I <- diag(nrow(full.Z))
         colnames(geno.I) <- paste0("CovarMat", seq_len(ncol(geno.I)))
         full.Z <- do.call(cbind, list(full.Z, geno.I))
-
         # add a genetic variance component
         sigma_g <- Matrix(runif(1, 0, 1), ncol=1, nrow=1, sparse=TRUE)
         rownames(sigma_g) <- "CovarMat"

--- a/src/fitGeneticPLGlmm.cpp
+++ b/src/fitGeneticPLGlmm.cpp
@@ -220,6 +220,7 @@ List fitGeneticPLGlmm(const arma::mat& Z, const arma::mat& X, const arma::mat& K
         Vmu = computeVmu(muvec, curr_disp, vardist);
         W = computeW(curr_disp, Dinv, vardist);
         Winv = W.i();
+
         // pre-compute matrics: X^T * W^-1, Z^T * W^-1
         arma::mat xTwinv = X.t() * Winv;
         arma::mat zTwin = Z.t() * Winv;
@@ -272,6 +273,7 @@ List fitGeneticPLGlmm(const arma::mat& Z, const arma::mat& X, const arma::mat& K
             if(REML){
                 arma::mat VstarZ = V_star_inv * Z;
                 VP_partial = precomp_list["PZZt"];
+
                 VS_partial = pseudovarPartial_VG(u_indices, Z,  VstarZ, K);
 
                 score_sigma = sigmaScoreREML_arma(VP_partial, y_star, P,

--- a/src/paramEst.cpp
+++ b/src/paramEst.cpp
@@ -30,6 +30,7 @@ arma::vec sigmaScoreREML_arma (const Rcpp::List& pvstar_i, const arma::vec& ysta
     for(int i=0; i < c; i++){
         const arma::mat& P_pvi = pvstar_i(i); // this is Vstar_inv * partial derivative
         const arma::mat& Pdifi = remldiffV(i);
+
         double lhs = -0.5 * arma::trace(Pdifi);
         arma::mat mid1(1, 1);
         mid1 = arma::trans(ystarminx) * P_pvi * Vstarinv * ystarminx;

--- a/src/pseudovarPartial.cpp
+++ b/src/pseudovarPartial.cpp
@@ -156,13 +156,14 @@ List pseudovarPartial_VG(const List& u_indices, const arma::mat& Z, const arma::
         arma::uvec u_idx = u_indices[i];
         arma::mat omat(n , n);
 
+        arma::mat VsZcols = VstarZ.cols(u_idx-1);
+        arma::mat Zcols = Z.cols(u_idx-1).t();
+
         if(i == c - 1){
-            omat = VstarZ.cols(u_idx-1) * K * Z.cols(u_idx-1);
+            omat = VstarZ.cols(u_idx-1) * K * Zcols;
         } else{
-            omat = VstarZ.cols(u_idx-1) * Z.cols(u_idx-1);
+            omat = VstarZ.cols(u_idx-1) * Zcols;
         }
-
-
 
         outlist[i] = omat;
     }


### PR DESCRIPTION
Using a random effect in the formula and a GRM resulted in a matrix multiplication error. The fix was to transpose the sub-matrix of Z subset by the columns of the relevant random effect level. This also revealed an error in the how the results were being collated with multiple random variables if one of them was the GRM/kinship matrix.